### PR TITLE
perf vendor events arm64: Fix incorrect CPU_CYCLE in metrics expr

### DIFF
--- a/tools/perf/pmu-events/arch/arm64/arm/neoverse-n3/metrics.json
+++ b/tools/perf/pmu-events/arch/arm64/arm/neoverse-n3/metrics.json
@@ -169,7 +169,7 @@
     },
     {
         "MetricName": "fp_ops_per_cycle",
-        "MetricExpr": "(FP_SCALE_OPS_SPEC + FP_FIXED_OPS_SPEC) / CPU_CYCLE",
+        "MetricExpr": "(FP_SCALE_OPS_SPEC + FP_FIXED_OPS_SPEC) / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by any instruction. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"
@@ -383,7 +383,7 @@
     },
     {
         "MetricName": "nonsve_fp_ops_per_cycle",
-        "MetricExpr": "FP_FIXED_OPS_SPEC / CPU_CYCLE",
+        "MetricExpr": "FP_FIXED_OPS_SPEC / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by an instruction that is not an SVE instruction. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"
@@ -421,7 +421,7 @@
     },
     {
         "MetricName": "sve_fp_ops_per_cycle",
-        "MetricExpr": "FP_SCALE_OPS_SPEC / CPU_CYCLE",
+        "MetricExpr": "FP_SCALE_OPS_SPEC / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by SVE instructions. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"

--- a/tools/perf/pmu-events/arch/arm64/arm/neoverse-v3/metrics.json
+++ b/tools/perf/pmu-events/arch/arm64/arm/neoverse-v3/metrics.json
@@ -169,7 +169,7 @@
     },
     {
         "MetricName": "fp_ops_per_cycle",
-        "MetricExpr": "(FP_SCALE_OPS_SPEC + FP_FIXED_OPS_SPEC) / CPU_CYCLE",
+        "MetricExpr": "(FP_SCALE_OPS_SPEC + FP_FIXED_OPS_SPEC) / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by any instruction. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"
@@ -383,7 +383,7 @@
     },
     {
         "MetricName": "nonsve_fp_ops_per_cycle",
-        "MetricExpr": "FP_FIXED_OPS_SPEC / CPU_CYCLE",
+        "MetricExpr": "FP_FIXED_OPS_SPEC / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by an instruction that is not an SVE instruction. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"
@@ -421,7 +421,7 @@
     },
     {
         "MetricName": "sve_fp_ops_per_cycle",
-        "MetricExpr": "FP_SCALE_OPS_SPEC / CPU_CYCLE",
+        "MetricExpr": "FP_SCALE_OPS_SPEC / CPU_CYCLES",
         "BriefDescription": "This metric measures floating point operations per cycle in any precision performed by SVE instructions. Operations are counted by computation and by vector lanes, fused computations such as multiply-add count as twice per vector lane for example.",
         "MetricGroup": "FP_Arithmetic_Intensity",
         "ScaleUnit": "1operations per cycle"


### PR DESCRIPTION
Some existing metrics for Neoverse N3 and V3 expressions use CPU_CYCLE to represent the number of cycles, but this is incorrect. The correct event to use is CPU_CYCLES.

I encountered this issue while working on a patch to add pmu events for Cortex A720 and A520 by reusing the existing patch for Neoverse N3 and V3 by James Clark [1] and my check script [2] reported this issue.

[1] https://lore.kernel.org/lkml/20250122163504.2061472-1-james.clark@linaro.org/
[2] https://github.com/cyyself/arm-pmu-check


Reviewed-by: James Clark <james.clark@linaro.org>
Link: https://lore.kernel.org/r/tencent_D4ED18476ADCE818E31084C60E3E72C14907@qq.com